### PR TITLE
Fix session ID usage for OCR permission check

### DIFF
--- a/readim.py
+++ b/readim.py
@@ -109,7 +109,7 @@ class readim(Plugin):
                         image = Image.open(io.BytesIO(image_data))
                         image_caption = self.model.caption_image(image)
                         e_context["context"].content = "我发给了你图片，内容是{}, ".format(image_caption)
-                        if self.allow_ocr.get(receiver, self.default_allow_ocr):
+                        if self.allow_ocr.get(session_id, self.default_allow_ocr):
                             image_ocr = ocr_from_image(image, lang=self.lang)
                             e_context["context"].content += "上面写了文字：{}(如果你看不明白上面写了什么, 请你忽略上面写的文字, 不需要告诉我)。".format(image_ocr)
                         e_context["context"].content += "请你假装你自己看到了这张图片的内容, 而不是我告诉你了描述。请假装你真的看到了图片内容，你的回答中千万不要透露你是假装看到的。"


### PR DESCRIPTION
ocr校验的字段好像有点问题，L85和L90在设置字段session_id来表达ocr开启与禁用，L112在进行是否要添加OCR相关的提示词时，校验的字段是receiver